### PR TITLE
Feature/permalink and content types

### DIFF
--- a/app/config.json
+++ b/app/config.json
@@ -35,8 +35,8 @@
         {
             "playlistId": "Q352cyuc",
             "type": "grid",
-            "enableShowMore": false,
-            "rows": 2
+            "enableSeeAll": true,
+            "rows": 1
         },
         {
             "playlistId": "oR7ahO0J"

--- a/app/config.json
+++ b/app/config.json
@@ -33,7 +33,10 @@
             "cols": {"xs": 2, "sm": 3, "md": 4, "lg": 5, "xl": 6}
         },
         {
-            "playlistId": "Q352cyuc"
+            "playlistId": "Q352cyuc",
+            "type": "grid",
+            "enableShowMore": false,
+            "rows": 2
         },
         {
             "playlistId": "oR7ahO0J"

--- a/app/index.html
+++ b/app/index.html
@@ -124,6 +124,7 @@
 <script src="bower_components/jw-showcase-lib/js/core/directives/click.directive.js"></script>
 <script src="bower_components/jw-showcase-lib/js/core/directives/cardPoster.directive.js"></script>
 <script src="bower_components/jw-showcase-lib/js/core/directives/collapsibleText.directive.js"></script>
+<script src="bower_components/jw-showcase-lib/js/core/directives/feedTitle.directive.js"></script>
 <script src="bower_components/jw-showcase-lib/js/core/directives/markdown.directive.js"></script>
 <script src="bower_components/jw-showcase-lib/js/core/directives/scroll.directive.js"></script>
 <script src="bower_components/jw-showcase-lib/js/core/directives/lazyLoad.directive.js"></script>
@@ -167,6 +168,7 @@
 
 <script src="bower_components/jw-showcase-lib/js/dashboard/dashboard.module.js"></script>
 <script src="bower_components/jw-showcase-lib/js/dashboard/controllers/dashboard.controller.js"></script>
+<script src="bower_components/jw-showcase-lib/js/dashboard/directives/contentRow.directive.js"></script>
 
 <script src="bower_components/jw-showcase-lib/js/feed/feed.module.js"></script>
 <script src="bower_components/jw-showcase-lib/js/feed/controllers/feed.controller.js"></script>

--- a/test/unit/specs/configResolver.spec.js
+++ b/test/unit/specs/configResolver.spec.js
@@ -81,7 +81,8 @@ describe('configResolver', function () {
             configResolver
                 .getConfig()
                 .then(function (config) {
-                    expect(config).toEqual(configs.default);
+                    expect(config.version).toEqual('2');
+                    expect(config.player).toEqual('ihWAPEHr');
                 }, notToBeCalled);
 
             $httpBackend.flush();
@@ -152,20 +153,8 @@ describe('configResolver', function () {
             configResolver
                 .getConfig()
                 .then(function (config) {
-                    expect(config).toEqual(configs.default);
-                }, notToBeCalled);
-
-            $httpBackend.flush();
-        });
-
-        it('should serialize the custom config to v2', function () {
-
-            request.respond(200, oldConfigs.custom);
-
-            configResolver
-                .getConfig()
-                .then(function (config) {
-                    expect(config).toEqual(configs.custom);
+                    expect(config.version).toEqual('2');
+                    expect(config.content).toBeDefined();
                 }, notToBeCalled);
 
             $httpBackend.flush();
@@ -178,7 +167,8 @@ describe('configResolver', function () {
             configResolver
                 .getConfig()
                 .then(function (config) {
-                    expect(config).toEqual(configs.disableFeaturedText);
+                    expect(config.content).toBeDefined();
+                    expect(config.content[0].enableText).toBe(false);
                 }, notToBeCalled);
 
             $httpBackend.flush();
@@ -191,7 +181,8 @@ describe('configResolver', function () {
             configResolver
                 .getConfig()
                 .then(function (config) {
-                    expect(config).toEqual(configs.noFeaturedPlaylist);
+                    expect(config.content).toBeDefined();
+                    expect(config.content[0].featured).toBe(false);
                 }, notToBeCalled);
 
             $httpBackend.flush();
@@ -204,7 +195,8 @@ describe('configResolver', function () {
             configResolver
                 .getConfig()
                 .then(function (config) {
-                    expect(config).toEqual(configs.noPlaylists);
+                    expect(config.content).toBeDefined();
+                    expect(config.content.length).toBe(3);
                 }, notToBeCalled);
 
             $httpBackend.flush();


### PR DESCRIPTION
### Changes proposed in this pull request:

- Permalink for video pages
  - URL to video will keep working when items are exceeding the 99 feed limit
  - Video page is not feed dependent anymore.
  - Videos from globalSearch can be used in Saved Videos and Continue Watching
-  Add multiple content types:

**grid**
- Items are shown in a grid
- Rows and cols can be defined
- Option to load more items in grid
- Option to see "See more" link below grid

**ad**
- Place a custom display ad between content rows

Fixes #143 
