### PR TITLE
Remove internal company player ID

### DIFF
--- a/app/config.json
+++ b/app/config.json
@@ -1,6 +1,6 @@
 {
     "version": "2",
-    "player": "N8axwZHA",
+    "player": "Insert a player ID from your JW Dashboard",
     "theme": "light",
     "siteName": "JW Showcase",
     "description": "JW Showcase is an open-source, dynamically generated video website built around JW Player and JW Platform services. It enables you to easily publish your JW Player-hosted video content with no coding and minimal configuration.",


### PR DESCRIPTION
The player ID mentioned in this is for an internal ads account and is being used without our consent.

### Changes proposed in this pull request:

Customer's are mistakenly using this player ID in their self-hosted showcase deployaments

Fixes #
Inserted a generic placeholder